### PR TITLE
fix(client): support graph-scoped legacy user auth paths

### DIFF
--- a/hugegraph-client/src/main/java/org/apache/hugegraph/api/auth/AuthAPI.java
+++ b/hugegraph-client/src/main/java/org/apache/hugegraph/api/auth/AuthAPI.java
@@ -27,23 +27,33 @@ public abstract class AuthAPI extends API {
     private static final String LEGACY_PATH = "graphs/%s/auth/%s";
     private static final String USER_PATH = "auth/%s";
 
+    private final boolean legacyGraphScoped;
+
     public AuthAPI(RestClient client) {
         super(client);
+        this.legacyGraphScoped = false;
         this.path(USER_PATH, this.type());
     }
 
     public AuthAPI(RestClient client, String graphSpace) {
         super(client);
+        this.legacyGraphScoped = false;
         this.path(PATH, graphSpace, this.type());
     }
 
     public AuthAPI(RestClient client, String graphSpace, String graph) {
         super(client);
-        if (!client.isSupportGs() && graph != null && !graph.isEmpty()) {
+        this.legacyGraphScoped = !client.isSupportGs() &&
+                                 graph != null && !graph.isEmpty();
+        if (this.legacyGraphScoped) {
             this.path(LEGACY_PATH, graph, this.type());
         } else {
             this.path(PATH, graphSpace, this.type());
         }
+    }
+
+    protected boolean legacyGraphScoped() {
+        return this.legacyGraphScoped;
     }
 
     public static String formatEntityId(Object id) {

--- a/hugegraph-client/src/main/java/org/apache/hugegraph/api/auth/AuthAPI.java
+++ b/hugegraph-client/src/main/java/org/apache/hugegraph/api/auth/AuthAPI.java
@@ -24,6 +24,7 @@ import org.apache.hugegraph.structure.auth.AuthElement;
 public abstract class AuthAPI extends API {
 
     private static final String PATH = "graphspaces/%s/auth/%s";
+    private static final String LEGACY_PATH = "graphs/%s/auth/%s";
     private static final String USER_PATH = "auth/%s";
 
     public AuthAPI(RestClient client) {
@@ -34,6 +35,15 @@ public abstract class AuthAPI extends API {
     public AuthAPI(RestClient client, String graphSpace) {
         super(client);
         this.path(PATH, graphSpace, this.type());
+    }
+
+    public AuthAPI(RestClient client, String graphSpace, String graph) {
+        super(client);
+        if (!client.isSupportGs() && graph != null && !graph.isEmpty()) {
+            this.path(LEGACY_PATH, graph, this.type());
+        } else {
+            this.path(PATH, graphSpace, this.type());
+        }
     }
 
     public static String formatEntityId(Object id) {

--- a/hugegraph-client/src/main/java/org/apache/hugegraph/api/auth/UserAPI.java
+++ b/hugegraph-client/src/main/java/org/apache/hugegraph/api/auth/UserAPI.java
@@ -30,8 +30,17 @@ import com.google.common.collect.ImmutableMap;
 
 public class UserAPI extends AuthAPI {
 
+    private final boolean legacyGraphScoped;
+
     public UserAPI(RestClient client, String graphSpace) {
         super(client, graphSpace);
+        this.legacyGraphScoped = false;
+    }
+
+    public UserAPI(RestClient client, String graphSpace, String graph) {
+        super(client, graphSpace, graph);
+        this.legacyGraphScoped = !client.isSupportGs() &&
+                                 graph != null && !graph.isEmpty();
     }
 
     @Override
@@ -70,8 +79,19 @@ public class UserAPI extends AuthAPI {
     }
 
     public User getByName(String name) {
-        Map<String, Object> params = ImmutableMap.of("name", name);
+        Map<String, Object> params = this.legacyGraphScoped ?
+                                     ImmutableMap.of("limit", -1) :
+                                     ImmutableMap.of("name", name);
         RestResult result = this.client.get(this.path(), params);
+        if (this.legacyGraphScoped) {
+            List<User> users = result.readList(this.type(), User.class);
+            for (User user : users) {
+                if (name.equals(user.name())) {
+                    return user;
+                }
+            }
+            return null;
+        }
         return result.readObject(User.class);
     }
 

--- a/hugegraph-client/src/main/java/org/apache/hugegraph/api/auth/UserAPI.java
+++ b/hugegraph-client/src/main/java/org/apache/hugegraph/api/auth/UserAPI.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.hugegraph.client.RestClient;
+import org.apache.hugegraph.rest.ClientException;
 import org.apache.hugegraph.rest.RestResult;
 import org.apache.hugegraph.structure.auth.User;
 import org.apache.hugegraph.structure.auth.User.UserRole;
@@ -30,17 +31,12 @@ import com.google.common.collect.ImmutableMap;
 
 public class UserAPI extends AuthAPI {
 
-    private final boolean legacyGraphScoped;
-
     public UserAPI(RestClient client, String graphSpace) {
         super(client, graphSpace);
-        this.legacyGraphScoped = false;
     }
 
     public UserAPI(RestClient client, String graphSpace, String graph) {
         super(client, graphSpace, graph);
-        this.legacyGraphScoped = !client.isSupportGs() &&
-                                 graph != null && !graph.isEmpty();
     }
 
     @Override
@@ -79,19 +75,17 @@ public class UserAPI extends AuthAPI {
     }
 
     public User getByName(String name) {
-        Map<String, Object> params = this.legacyGraphScoped ?
-                                     ImmutableMap.of("limit", -1) :
-                                     ImmutableMap.of("name", name);
-        RestResult result = this.client.get(this.path(), params);
-        if (this.legacyGraphScoped) {
-            List<User> users = result.readList(this.type(), User.class);
+        if (this.legacyGraphScoped()) {
+            List<User> users = this.list(-1);
             for (User user : users) {
                 if (name.equals(user.name())) {
                     return user;
                 }
             }
-            return null;
+            throw new ClientException("User '%s' does not exist", name);
         }
+        Map<String, Object> params = ImmutableMap.of("name", name);
+        RestResult result = this.client.get(this.path(), params);
         return result.readObject(User.class);
     }
 

--- a/hugegraph-client/src/main/java/org/apache/hugegraph/driver/AuthManager.java
+++ b/hugegraph-client/src/main/java/org/apache/hugegraph/driver/AuthManager.java
@@ -66,7 +66,7 @@ public class AuthManager {
         this.targetAPI = new TargetAPI(client, graphSpace);
         this.groupAPI = new GroupAPI(client);
         this.graphSpaceGroupAPI = new GroupAPI(client, graphSpace);
-        this.userAPI = new UserAPI(client, graphSpace);
+        this.userAPI = new UserAPI(client, graphSpace, graph);
         this.accessAPI = new AccessAPI(client, graphSpace);
         this.projectAPI = new ProjectAPI(client, graphSpace);
         this.belongAPI = new BelongAPI(client, graphSpace);

--- a/hugegraph-client/src/test/java/org/apache/hugegraph/unit/AuthApiPathTest.java
+++ b/hugegraph-client/src/test/java/org/apache/hugegraph/unit/AuthApiPathTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 
 import org.apache.hugegraph.api.auth.UserAPI;
 import org.apache.hugegraph.client.RestClient;
+import org.apache.hugegraph.rest.ClientException;
 import org.apache.hugegraph.structure.auth.User;
 import org.apache.hugegraph.testutil.Assert;
 
@@ -49,6 +50,17 @@ public class AuthApiPathTest {
         client.setSupportGs(true);
 
         UserAPI api = new UserAPI(client, "DEFAULT", "hugegraph");
+
+        Assert.assertEquals("graphspaces/DEFAULT/auth/users", api.path());
+        client.close();
+    }
+
+    @Test
+    public void testLegacyServerWithoutGraphUsesGraphSpaceScopedAuthPath() {
+        RestClient client = new RestClient("http://localhost", "", "", 1);
+        client.setSupportGs(false);
+
+        UserAPI api = new UserAPI(client, "DEFAULT", null);
 
         Assert.assertEquals("graphspaces/DEFAULT/auth/users", api.path());
         client.close();
@@ -91,6 +103,11 @@ public class AuthApiPathTest {
             UserAPI api = new UserAPI(client, "DEFAULT", "hugegraph");
             User user = api.getByName("admin");
             Assert.assertEquals("admin", user.name());
+            Assert.assertThrows(ClientException.class,
+                                () -> api.getByName("missing"),
+                                e -> Assert.assertContains(
+                                        "User 'missing' does not exist",
+                                        e.getMessage()));
         } finally {
             client.close();
             server.stop(0);

--- a/hugegraph-client/src/test/java/org/apache/hugegraph/unit/AuthApiPathTest.java
+++ b/hugegraph-client/src/test/java/org/apache/hugegraph/unit/AuthApiPathTest.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hugegraph.unit;
+
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.Test;
+
+import org.apache.hugegraph.api.auth.UserAPI;
+import org.apache.hugegraph.client.RestClient;
+import org.apache.hugegraph.structure.auth.User;
+import org.apache.hugegraph.testutil.Assert;
+
+import com.sun.net.httpserver.HttpServer;
+
+public class AuthApiPathTest {
+
+    @Test
+    public void testLegacyServerUsesGraphScopedAuthPath() {
+        RestClient client = new RestClient("http://localhost", "", "", 1);
+        client.setSupportGs(false);
+
+        UserAPI api = new UserAPI(client, "DEFAULT", "hugegraph");
+
+        Assert.assertEquals("graphs/hugegraph/auth/users", api.path());
+        client.close();
+    }
+
+    @Test
+    public void testModernServerUsesGraphSpaceScopedAuthPath() {
+        RestClient client = new RestClient("http://localhost", "", "", 1);
+        client.setSupportGs(true);
+
+        UserAPI api = new UserAPI(client, "DEFAULT", "hugegraph");
+
+        Assert.assertEquals("graphspaces/DEFAULT/auth/users", api.path());
+        client.close();
+    }
+
+    @Test
+    public void testLegacyGetByNameReadsAllUsersFromWrapper() throws Exception {
+        HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1",
+                                                                    0), 0);
+        server.createContext("/graphs/hugegraph/auth/users", exchange -> {
+            boolean unlimited = "limit=-1".equals(
+                                exchange.getRequestURI().getQuery());
+            StringBuilder content = new StringBuilder("{\"users\":[");
+            for (int i = 0; i < 100; i++) {
+                if (i > 0) {
+                    content.append(',');
+                }
+                content.append("{\"id\":\"").append(i)
+                       .append("\",\"user_name\":\"user_")
+                       .append(i).append("\"}");
+            }
+            if (unlimited) {
+                content.append(",{\"id\":\"-30:admin\",")
+                       .append("\"user_name\":\"admin\"}");
+            }
+            byte[] body = content.append("]}").toString()
+                                 .getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(200, body.length);
+            try (OutputStream output = exchange.getResponseBody()) {
+                output.write(body);
+            }
+        });
+        server.start();
+
+        RestClient client = new RestClient(
+                "http://127.0.0.1:" + server.getAddress().getPort(),
+                "admin", "password", 1);
+        client.setSupportGs(false);
+        try {
+            UserAPI api = new UserAPI(client, "DEFAULT", "hugegraph");
+            User user = api.getByName("admin");
+            Assert.assertEquals("admin", user.name());
+        } finally {
+            client.close();
+            server.stop(0);
+        }
+    }
+}

--- a/hugegraph-client/src/test/java/org/apache/hugegraph/unit/UnitTestSuite.java
+++ b/hugegraph-client/src/test/java/org/apache/hugegraph/unit/UnitTestSuite.java
@@ -26,6 +26,7 @@ import org.junit.runners.Suite;
         PathSerializerTest.class,
         RestResultTest.class,
         RestClientStatusTest.class,
+        AuthApiPathTest.class,
         BatchElementRequestTest.class,
         PropertyKeyTest.class,
         IndexLabelTest.class,


### PR DESCRIPTION
## Summary

- use `graphs/{graph}/auth/users` when the server does not support GraphSpace;
- request all legacy users with `limit=-1`, then find the exact username in the Server 1.5 `users` wrapper;
- preserve the existing GraphSpace-scoped path and `name` query for modern servers;
- add regression coverage for the legacy path, a target user after the default first 100 records, and the unchanged modern path.

## Environment and reproduction

- HugeGraph Server: 1.5.0, Core 1.5.0, REST API 0.71.0.0
- Authentication: `StandardAuthenticator`
- Context: `DEFAULT / hugegraph`
- PR base: `apache/hugegraph-toolchain@be7ef3ae`
- OS: macOS

The full Before flow and three step-by-step screenshots are recorded in #759.

## After verification

1. Real Server 1.5 contract:
   - `GET /graphs/hugegraph/auth/users?limit=-1` -> HTTP 200
   - `GET /auth/users?limit=-1` -> HTTP 404
   - response wrapper -> `users`
2. Patched Java Client against the real Server 1.5 runtime:
   - `client.auth().getUserByName("admin")` -> `user=admin success=true`
3. Regression suite:
   - 63 tests, 0 failures, 0 errors
   - 0 Checkstyle violations

### Step 1: verify the real Server 1.5 contract

<img width="1280" height="720" alt="Server 1.5 legacy auth contract" src="https://github.com/user-attachments/assets/f94c9d59-9e4b-4669-8f31-cfa938b9a5f0" />

### Step 2: run the patched Java Client against Server 1.5

<img width="1280" height="720" alt="Patched client user lookup succeeds" src="https://github.com/user-attachments/assets/c87cf50b-c7ed-44ec-894d-b11e16c5bf9b" />

### Step 3: run focused and unit regression tests

<img width="1280" height="720" alt="Client regression tests pass" src="https://github.com/user-attachments/assets/89346e4b-b1b4-4584-a6d5-41ac151feec6" />

## Tests

```bash
cd hugegraph-client
mvn test -Dtest=AuthApiPathTest,UnitTestSuite \
  -Dmaven.javadoc.skip=true -ntp
```

Fixes #759
